### PR TITLE
Moved Scratch org deletion in after_script step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,6 @@ script:
 - sfdx force:org:create -v HubOrg -s -f config/project-scratch-def.json -a ciorg
 - sfdx force:source:push -u ciorg
 - sfdx force:apex:test:run -u ciorg -c -r human
+
+after_script:
 - sfdx force:org:delete -u ciorg -p


### PR DESCRIPTION
Moved the Scratch org deletion command in the `after_script` step in order to ensure that it is deleted whether the tests succeed or not.