### PR TITLE
Removed os: trusty (causes Travis build fail)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: true
-os: trusty
 cache: false
 
 env:


### PR DESCRIPTION
"os: trusty" is wrong or deprecated; will cause Travis CI build to fail. Command should be "dist: trusty", but just remove line altogether and Travis will default to most currently imaged OS and insert the proper os and dist lines automatically: 

[https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide]
"Repositories without an explicit operating system os: key in their travis.yml file will use Linux Ubuntu Xenial 16.04."